### PR TITLE
Add podspec for Cocoapods support.

### DIFF
--- a/RNHandoff.android.js
+++ b/RNHandoff.android.js
@@ -1,7 +1,7 @@
-import { Component } from 'react';
+import { PureComponent } from 'react'
 
-export default class Handoff extends Component {
-    render() {
-        return null;
-    }
+export default class Handoff extends PureComponent {
+  render() {
+    return null
+  }
 }

--- a/RNHandoff.ios.js
+++ b/RNHandoff.ios.js
@@ -1,28 +1,32 @@
-import { Component } from 'react';
+import { PureComponent } from 'react'
 import { NativeModules } from 'react-native'
 
-const { RNHandoff } = NativeModules;
+const { RNHandoff } = NativeModules
 
-let id = 0;
+export default class Handoff extends PureComponent {
+  state = {
+    active: false,
+    id: 'react-native-handoff',
+  }
 
-export default class Handoff extends Component {
-    id = -1;
+  componentDidMount() {
+    const { type, title, url } = this.props
+    const { id } = this.state
 
-    componentWillMount() {
-        const { type, title, url } = this.props;
+    RNHandoff.becomeCurrent(id, type, title, url)
 
-        this.id = ++id;
+    this.setState({ active: true })
+  }
 
-        RNHandoff.becomeCurrent(this.id, type, title, url);
+  componentWillUnmount() {
+    const { active, id } = this.state
+
+    if (active) {
+      RNHandoff.invalidate(id)
     }
+  }
 
-    componentWillUnmount() {
-        if (this.id !== -1) {
-            RNHandoff.invalidate(this.id);
-        }
-    }
-
-    render() {
-        return null;
-    }
+  render() {
+    return null
+  }
 }

--- a/react-native-handoff.podspec
+++ b/react-native-handoff.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RNHandoff"
+  s.version      = package['version']
+  s.summary      = "React Native Handoff support for iOS"
+
+  s.homepage     = "https://github.com/IzaakSultan/react-native-handoff"
+  s.license      = "MIT"
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/IzaakSultan/react-native-handoff.git" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Hi @IzaakSultan 👋 

Thanks for this package, concise and useful! 🙏

I made a couple of edits and I think it would be great if you merge them into your repo and publish a new version on NPM. I hope you're ok with me making this PR 🙄

I did only two things:

1. Added a `react-native-handoff.podspec` to the project root, to support module installations via Cocoapods.
1. Refactored the JS class to use `PureComponent` instead of `Component` (to avoid unwanted rerenders) and to update the `componentWillMount` lifecycle that is [officially deprecated](https://reactjs.org/docs/react-component.html#mounting).

Do you agree with these changes?